### PR TITLE
Prepare for Istio canary usage - part 2

### DIFF
--- a/clusters/armadillo/istio/installation/operator-usage/istio-control-plane.yaml
+++ b/clusters/armadillo/istio/installation/operator-usage/istio-control-plane.yaml
@@ -59,11 +59,15 @@ spec:
 
   meshConfig:
     accessLogFile: /dev/stdout
+    defaultConfig:
+      proxyMetadata:
+        # Enable Istio agent to handle DNS requests for known hosts
+        # Unknown hosts will automatically be resolved using upstream dns servers in resolv.conf
+        ISTIO_META_DNS_CAPTURE: "true"
 
   values:
     global:
       # pilotCertProvider: kubernetes
-      controlPlaneSecurityEnabled: true
       multiCluster:
         # clusterName: armadillo
         enabled: true # Only used for istio-sidecar-injector ConfigMap

--- a/clusters/bison/istio/installation/operator-usage/istio-control-plane.yaml
+++ b/clusters/bison/istio/installation/operator-usage/istio-control-plane.yaml
@@ -59,11 +59,15 @@ spec:
 
   meshConfig:
     accessLogFile: /dev/stdout
+    defaultConfig:
+      proxyMetadata:
+        # Enable Istio agent to handle DNS requests for known hosts
+        # Unknown hosts will automatically be resolved using upstream dns servers in resolv.conf
+        ISTIO_META_DNS_CAPTURE: "true"
 
   values:
     global:
       # pilotCertProvider: kubernetes
-      controlPlaneSecurityEnabled: true
       multiCluster:
         # clusterName: bison
         enabled: true # Only used for istio-sidecar-injector ConfigMap

--- a/clusters/dolphin/istio/installation/operator-usage/istio-control-plane.yaml
+++ b/clusters/dolphin/istio/installation/operator-usage/istio-control-plane.yaml
@@ -51,11 +51,15 @@ spec:
 
   meshConfig:
     accessLogFile: /dev/stdout
+    defaultConfig:
+      proxyMetadata:
+        # Enable Istio agent to handle DNS requests for known hosts
+        # Unknown hosts will automatically be resolved using upstream dns servers in resolv.conf
+        ISTIO_META_DNS_CAPTURE: "true"
 
   values:
     global:
       # pilotCertProvider: kubernetes
-      controlPlaneSecurityEnabled: true
       multiCluster:
         # clusterName: dolphin
         enabled: true # Only used for istio-sidecar-injector ConfigMap

--- a/docs/2-local-clusters/argo-cd-without-istio-operator.md
+++ b/docs/2-local-clusters/argo-cd-without-istio-operator.md
@@ -527,17 +527,17 @@ The next step will install Argo CD drive Git repository sync, and that would ove
 {
     kubectl apply \
         --context kind-armadillo \
-        -f ./clusters/armadillo/istio/installation/no-operator-install/istio-control-plane-install.yaml \
-        -f ./clusters/armadillo/istio/installation/no-operator-install/istio-multicluster-gateways-install.yaml \
-        -f ./clusters/armadillo/istio/installation/no-operator-install/istio-external-gateways-install.yaml \
-        -f ./clusters/armadillo/istio/installation/no-operator-install/istio-management-gateway-install.yaml
+        -f ./clusters/armadillo/istio/installation/no-operator-install/1.7.8/istio-control-plane-install.yaml \
+        -f ./clusters/armadillo/istio/installation/no-operator-install/1.7.8/istio-multicluster-gateways-install.yaml \
+        -f ./clusters/armadillo/istio/installation/no-operator-install/1.7.8/istio-external-gateways-install.yaml \
+        -f ./clusters/armadillo/istio/installation/no-operator-install/1.7.8/istio-management-gateway-install.yaml
 
     kubectl apply \
         --context kind-bison \
-        -f ./clusters/bison/istio/installation/no-operator-install/istio-control-plane-install.yaml \
-        -f ./clusters/bison/istio/installation/no-operator-install/istio-multicluster-gateways-install.yaml \
-        -f ./clusters/bison/istio/installation/no-operator-install/istio-external-gateways-install.yaml \
-        -f ./clusters/bison/istio/installation/no-operator-install/istio-management-gateway-install.yaml
+        -f ./clusters/bison/istio/installation/no-operator-install/1.7.8/istio-control-plane-install.yaml \
+        -f ./clusters/bison/istio/installation/no-operator-install/1.7.8/istio-multicluster-gateways-install.yaml \
+        -f ./clusters/bison/istio/installation/no-operator-install/1.7.8/istio-external-gateways-install.yaml \
+        -f ./clusters/bison/istio/installation/no-operator-install/1.7.8/istio-management-gateway-install.yaml
 }
 ```
 


### PR DESCRIPTION
Continuation of #9 

Fixed

- Documentation referred to old file path

Updated

- Remove flag that's no longer supported for Istio v1.8+

To be completed

- In the next update, I will remove Istio Core DNS from the spec. This will mean that the IstioOperator controller based step will no longer work for v1.7. This shouldn't cause any issues with the existing Argo CD driven setup, as it uses manifest generation approach which contains Istio Core DNS as a part of the installation manifest.